### PR TITLE
Prevent saving log entry when clicking toggleActiveProject -buttons

### DIFF
--- a/client/src/components/AddProjectForm/index.js
+++ b/client/src/components/AddProjectForm/index.js
@@ -52,6 +52,7 @@ export default class AddProjectForm extends Component {
           onClick={this.addProject}
           className={cx(styles.submitButton, styles.buttonGreen)}
           disabled={this.state.submitButtonDisabled}
+          type="button"
         >
           <Icon name="plus" /> Lisää
         </Button>
@@ -75,6 +76,7 @@ export default class AddProjectForm extends Component {
           onClick={this.toggleShowProjectForm}
           className={classes}
           active={showForm}
+          type="button"
         >
           <Icon name={icon} />
         </Button>

--- a/client/src/components/StatusForm/index.js
+++ b/client/src/components/StatusForm/index.js
@@ -36,7 +36,9 @@ export default class StatusForm extends Component {
     this.setState({ color });
   }
 
-  toggleActiveProject = id => {
+  toggleActiveProject = (id, e) => {
+    e.preventDefault();
+
     const activeProjects = this.state.activeProjects || [];
     const isProjectActive = activeProjects.includes(id);
 

--- a/client/src/components/StatusForm/index.js
+++ b/client/src/components/StatusForm/index.js
@@ -152,6 +152,7 @@ export default class StatusForm extends Component {
                 active={this.state.activeProjects && this.state.activeProjects.indexOf(project.id) != -1}
                 title={project.name}
                 disabled={project.disabled}
+                type="button"
               >
                 {project.name}
               </Button>


### PR DESCRIPTION
Fixes some Enter-pressing corner cases as some of the buttons were not defined as `type="button"`. Also fixes a bug that causes new log entry to be saved while toggling projects.